### PR TITLE
feat: upgrade to use TypeScript 2.0 instead of 1.7.3 for parsing

### DIFF
--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -186,5 +186,4 @@ export function generateFileNamePairs(
       };
     });
   }
-  return null;
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "chalk": "^1.1.3",
     "diff": "^2.2.3",
     "minimist": "^1.2.0",
-    "typescript": "1.7.3"
+    "typescript": "2.0.10"
   },
   "devDependencies": {
     "chai": "^2.1.1",

--- a/test/unit_test.ts
+++ b/test/unit_test.ts
@@ -432,6 +432,7 @@ function getMockHost(files: {[name: string]: string}): ts.CompilerHost {
     getCanonicalFileName: (filename) => filename,
     getCurrentDirectory: () => './',
     getNewLine: () => '\n',
+    getDirectories: () => []
   };
 }
 


### PR DESCRIPTION
Update the TypeScript used to 2.0 which allows using 2.0 specific features in project that uses `ts-api-guardian`.