### PR TITLE
test: test for emitting type literals

### DIFF
--- a/test/fixtures/type_literals.d.ts
+++ b/test/fixtures/type_literals.d.ts
@@ -1,0 +1,7 @@
+export class UsesTypeLiterals {
+  a: number | undefined;
+  b: number | null;
+  c: number | true;
+  d: number | null | undefined;
+  e: Array<string | null | undefined>;
+}

--- a/test/fixtures/type_literals_expected.d.ts
+++ b/test/fixtures/type_literals_expected.d.ts
@@ -1,0 +1,7 @@
+export class UsesTypeLiterals {
+  a: number | undefined;
+  b: number | null;
+  c: number | true;
+  d: number | null | undefined;
+  e: Array<string | null | undefined>;
+}

--- a/test/integration_test.ts
+++ b/test/integration_test.ts
@@ -50,6 +50,10 @@ describe('integration test: public api', () => {
     ]);
   });
 
+  it('should support type literals', () => {
+    check('test/fixtures/type_literals.d.ts', 'test/fixtures/type_literals_expected.d.ts');
+  });
+
   it('should throw on passing a .ts file as an input', () => {
     chai.assert.throws(() => {
       main.publicApi('test/fixtures/empty.ts');


### PR DESCRIPTION
Adds tests for emitting types with type literals such as `null` and `undefined`.