### PR TITLE
fix: allow exports that match `stripExportPattern` to be aliases

### DIFF
--- a/lib/serializer.ts
+++ b/lib/serializer.ts
@@ -154,6 +154,9 @@ class ResolvedDeclarationEmitter {
           return s;
         }
         if (resolvedSymbol.name !== s.name) {
+          if (this.options.stripExportPattern && s.name.match(this.options.stripExportPattern)) {
+            return s;
+          }
           throw new Error(
               `Symbol "${resolvedSymbol.name}" was aliased as "${s.name}". ` +
               `Aliases are not supported."`);

--- a/test/cli_e2e_test.ts
+++ b/test/cli_e2e_test.ts
@@ -80,6 +80,16 @@ describe('cli: e2e test', () => {
         path.join(outDir, 'underscored.d.ts'), 'test/fixtures/underscored_expected.d.ts');
   });
 
+  it('should not throw for aliased stripped exports', () => {
+    const {stdout, status} = execute([
+      '--out', path.join(outDir, 'stripped_alias.d.ts'), '--stripExportPattern', '^__.*',
+      'test/fixtures/stripped_alias.d.ts'
+    ]);
+    chai.assert.equal(status, 0);
+    assertFileEqual(
+        path.join(outDir, 'stripped_alias.d.ts'), 'test/fixtures/stripped_alias_expected.d.ts');
+  });
+
   it('should verify respecting --stripExportPattern', () => {
     const {stdout, status} = execute([
       '--verify', 'test/fixtures/underscored_expected.d.ts', 'test/fixtures/underscored.d.ts',

--- a/test/fixtures/stripped_alias.d.ts
+++ b/test/fixtures/stripped_alias.d.ts
@@ -1,0 +1,3 @@
+export {original_symbol as __private_symbol} from './stripped_alias_original';
+export class B {
+}

--- a/test/fixtures/stripped_alias_expected.d.ts
+++ b/test/fixtures/stripped_alias_expected.d.ts
@@ -1,0 +1,2 @@
+export class B {
+}

--- a/test/fixtures/stripped_alias_original.d.ts
+++ b/test/fixtures/stripped_alias_original.d.ts
@@ -1,0 +1,1 @@
+export let original_symbol: number;


### PR DESCRIPTION
**Current Behavior**

Reports error for aliased symbols even if those symbols will eventually be ignored by strip exports.

**New Behavior**

Skips aliased symbols that match `skipExportPattern` even if the symbol is aliased.

Fixes #17 