### PR TITLE
fix: handle paths and line endings in a cross-platform compatible way…

### DIFF
--- a/bin/ts-api-guardian.cmd
+++ b/bin/ts-api-guardian.cmd
@@ -1,0 +1,4 @@
+@echo off
+node %~dp0ts-api-guardian %*
+exit /b %errorlevel%
+

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -181,7 +181,7 @@ export function generateFileNamePairs(
 
     return argv._.map(fileName => {
       return {
-        entrypoint: fileName,
+        entrypoint: path.normalize(fileName),
         goldenFile: path.join(goldenDir, path.relative(rootDir, fileName))
       };
     });

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -2,6 +2,7 @@ import {createPatch} from 'diff';
 import * as fs from 'fs';
 import * as path from 'path';
 import {SerializationOptions, publicApi} from './serializer';
+import * as eol from 'eol';
 
 export {SerializationOptions, publicApi} from './serializer';
 
@@ -17,10 +18,10 @@ export function verifyAgainstGoldenFile(
   const actual = publicApi(entrypoint, options);
   const expected = fs.readFileSync(goldenFile).toString();
 
-  if (actual === expected) {
+  if (actual.replace(/(\r|\n)/g, '') === expected.replace(/(\r|\n)/g, '')) {
     return '';
   } else {
-    const patch = createPatch(goldenFile, expected, actual, 'Golden file', 'Generated API');
+    const patch = createPatch(goldenFile, eol.auto(expected), eol.auto(actual), 'Golden file', 'Generated API');
 
     // Remove the header of the patch
     const start = patch.indexOf('\n', patch.indexOf('\n') + 1) + 1;

--- a/lib/serializer.ts
+++ b/lib/serializer.ts
@@ -69,7 +69,7 @@ class ResolvedDeclarationEmitter {
   }
 
   emit(): string {
-    const sourceFile = this.program.getSourceFiles().filter(sf => sf.fileName === this.fileName)[0];
+    const sourceFile = this.program.getSourceFiles().filter(sf => path.normalize(sf.fileName) === this.fileName)[0];
     if (!sourceFile) {
       throw new Error(`Source file "${this.fileName}" not found`);
     }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "diff": "^2.2.3",
+    "eol": "^0.6.0",
     "minimist": "^1.2.0",
     "typescript": "2.0.10"
   },

--- a/test/cli_unit_test.ts
+++ b/test/cli_unit_test.ts
@@ -1,5 +1,6 @@
 /// <reference path="../typings/chai/chai.d.ts"/>
 import chai = require('chai');
+import * as path from 'path';
 import * as ts from 'typescript';
 import {parseArguments, generateFileNamePairs} from '../lib/cli';
 
@@ -70,8 +71,8 @@ describe('cli: generateFileNamePairs', () => {
   it('should generate file pairs in multi-file mode according to current directory', () => {
     chai.assert.deepEqual(
         generateFileNamePairs({_: ['src/first.d.ts', 'src/second.d.ts'], outDir: 'bank'}, 'out'), [
-          {entrypoint: 'src/first.d.ts', goldenFile: 'bank/src/first.d.ts'},
-          {entrypoint: 'src/second.d.ts', goldenFile: 'bank/src/second.d.ts'}
+          {entrypoint: path.normalize('src/first.d.ts'), goldenFile: path.normalize('bank/src/first.d.ts')},
+          {entrypoint: path.normalize('src/second.d.ts'), goldenFile: path.normalize('bank/src/second.d.ts')}
         ]);
   });
 
@@ -80,8 +81,8 @@ describe('cli: generateFileNamePairs', () => {
         generateFileNamePairs(
             {_: ['src/first.d.ts', 'src/second.d.ts'], outDir: 'bank', rootDir: 'src'}, 'out'),
         [
-          {entrypoint: 'src/first.d.ts', goldenFile: 'bank/first.d.ts'},
-          {entrypoint: 'src/second.d.ts', goldenFile: 'bank/second.d.ts'}
+          {entrypoint: path.normalize('src/first.d.ts'), goldenFile: path.normalize('bank/first.d.ts')},
+          {entrypoint: path.normalize('src/second.d.ts'), goldenFile: path.normalize('bank/second.d.ts')}
         ]);
   });
 });

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -3,6 +3,11 @@ import chai = require('chai');
 import * as fs from 'fs';
 import * as path from 'path';
 
+export function removeEol(text: string) {
+  if (!text) return text;
+  return text.replace(/\r/g, '').replace(/\n/g, '');
+}
+
 export function unlinkRecursively(file: string) {
   if (fs.statSync(file).isDirectory()) {
     for (const f of fs.readdirSync(file)) {
@@ -16,5 +21,5 @@ export function unlinkRecursively(file: string) {
 
 export function assertFileEqual(actualFile: string, expectedFile: string) {
   chai.assert.equal(
-      fs.readFileSync(actualFile).toString(), fs.readFileSync(expectedFile).toString());
+      removeEol(fs.readFileSync(actualFile).toString()), removeEol(fs.readFileSync(expectedFile).toString()));
 }

--- a/test/integration_test.ts
+++ b/test/integration_test.ts
@@ -2,8 +2,9 @@
 import chai = require('chai');
 import * as fs from 'fs';
 import * as path from 'path';
+import * as eol from 'eol';
 import * as main from '../lib/main';
-import {assertFileEqual, unlinkRecursively} from './helpers';
+import {assertFileEqual, unlinkRecursively, removeEol} from './helpers';
 
 describe('integration test: public api', () => {
   let _warn = null;
@@ -108,7 +109,7 @@ describe('integration test: verifyAgainstGoldenFile', () => {
   it('should check an entrypoint against a golden file with proper diff message', () => {
     const diff = main.verifyAgainstGoldenFile(
         'test/fixtures/verify_entrypoint.d.ts', 'test/fixtures/verify_expected.d.ts');
-    chai.assert.equal(diff, fs.readFileSync('test/fixtures/verify.patch').toString());
+    chai.assert.equal(eol.auto(diff), eol.auto(fs.readFileSync('test/fixtures/verify.patch').toString()));
   });
 
   it('should respect serialization options', () => {
@@ -120,5 +121,5 @@ describe('integration test: verifyAgainstGoldenFile', () => {
 });
 
 function check(sourceFile: string, expectedFile: string, options: main.SerializationOptions = {}) {
-  chai.assert.equal(main.publicApi(sourceFile, options), fs.readFileSync(expectedFile).toString());
+  chai.assert.equal(removeEol(main.publicApi(sourceFile, options)), removeEol(fs.readFileSync(expectedFile).toString()));
 }


### PR DESCRIPTION
… (#13)

Mostly I was able to normalize paths and line endings. However some files in the integration tests used mixed line endings which the eol module was unable to normalize. Therefore I decided to ignore line endings in those tests.