### PR TITLE
fix: support enum values as value types

### DIFF
--- a/test/fixtures/enum_as_type.d.ts
+++ b/test/fixtures/enum_as_type.d.ts
@@ -1,0 +1,8 @@
+export declare enum Foo {
+  Alpha = 0,
+  Beta = 1,
+}
+
+export interface Bar {
+  field: Foo.Alpha,
+}

--- a/test/fixtures/enum_as_type_expected.d.ts
+++ b/test/fixtures/enum_as_type_expected.d.ts
@@ -1,0 +1,8 @@
+export interface Bar {
+  field: Foo.Alpha,
+}
+
+export declare enum Foo {
+  Alpha = 0,
+  Beta = 1,
+}

--- a/test/integration_test.ts
+++ b/test/integration_test.ts
@@ -54,6 +54,10 @@ describe('integration test: public api', () => {
     check('test/fixtures/type_literals.d.ts', 'test/fixtures/type_literals_expected.d.ts');
   });
 
+  it('should allow enums as types', () => {
+    check('test/fixtures/enum_as_type.d.ts', 'test/fixtures/enum_as_type_expected.d.ts');
+  });
+
   it('should throw on passing a .ts file as an input', () => {
     chai.assert.throws(() => {
       main.publicApi('test/fixtures/empty.ts');


### PR DESCRIPTION
Currently if the guardian sees a type of the form X.Y, it assumes X is a module identifier (import * as X from ...). However, X could also be an enum name, a class declaration, or some other container type which can hold values.

This change checks whether X is in fact a module identifier instead of assuming it is, which allows enums and other nested value types.