### PR TITLE
chore: bump version after release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-api-guardian",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Guards the API of TypeScript libraries!",
   "main": "build/lib/main.js",
   "typings": "build/definitions/main.d.ts",


### PR DESCRIPTION
Looks like the package version was not bumped after the release